### PR TITLE
Fixed the code cell default theme.

### DIFF
--- a/Reddish_Theme.json
+++ b/Reddish_Theme.json
@@ -228,7 +228,7 @@
     "backgroundColor": "#FFF"
   },
   "editor": {
-    "codeCellTheme": "Crimson Editor",
+    "codeCellTheme": "crimson_editor",
     "markdownCellTheme": "textmate"
   },
   "css": {


### PR DESCRIPTION
Thanks for the theme! I corrected the code cell default theme, otherwise code cells failed to load in the preview. Here are the code cell theme names: https://github.com/HappenApps/Quiver/wiki/Supported-Themes
